### PR TITLE
create WebpackManifest singleton class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :webpack_manifest_reload if RunningEnv.using_webpack_dev_server?
+
+  private
+
+  # webpack-dev-serverを使っているときは、actionごとにmanifest.jsonを読みに行く
+  def webpack_manifest_reload
+    WebpackManifest.instance.fetch_content
+  end
 end

--- a/app/helpers/running_env.rb
+++ b/app/helpers/running_env.rb
@@ -1,5 +1,0 @@
-module RunningEnv
-  def self.remote?
-    ENV['RAILS_ENV'] != 'development'
-  end
-end

--- a/app/helpers/webpack_bundle_helper.rb
+++ b/app/helpers/webpack_bundle_helper.rb
@@ -39,15 +39,6 @@ module WebpackBundleHelper
   private
 
   def manifest
-    if RunningEnv.remote?
-      @manifest ||= JSON.parse(File.read('public/packs/manifest.json'))
-    else
-      conn = Faraday::Connection.new(url: 'http://proxy:3002') do |builder|
-        builder.use Faraday::Adapter::NetHttp
-      end
-
-      res = conn.get '/packs/manifest.json'
-      @manifest ||= JSON.parse(res.body)
-    end
+    WebpackManifest.instance.content
   end
 end

--- a/app/lib/running_env.rb
+++ b/app/lib/running_env.rb
@@ -1,0 +1,5 @@
+module RunningEnv
+  def self.using_webpack_dev_server?
+    Rails.env.development?
+  end
+end

--- a/app/lib/webpack_manifest.rb
+++ b/app/lib/webpack_manifest.rb
@@ -1,0 +1,27 @@
+class WebpackManifest
+  MANIFEST_PATH = 'public/packs/manifest.json'
+
+  include Singleton
+
+  attr_reader :content
+
+  # webpack-dev-serverを使っているときにのみ、actionごとに呼ばれるメソッド
+  def fetch_content
+    conn = Faraday::Connection.new(url: 'http://proxy:3002') do |builder|
+      builder.use Faraday::Adapter::NetHttp
+    end
+
+    begin
+      res = conn.get '/packs/manifest.json'
+      @content = JSON.parse(res.body)
+    rescue Faraday::ConnectionFailed
+      sleep 2
+      retry
+    end
+  end
+
+  # webpack-dev-serverを使っていないときにのみ、起動時に呼ばれるメソッド
+  def load_content
+    @content = JSON.parse(File.read(MANIFEST_PATH))
+  end
+end

--- a/config/initializers/webpack.rb
+++ b/config/initializers/webpack.rb
@@ -1,0 +1,2 @@
+# webpack-dev-serverを使わない場合には、initializeの際にmanifest.jsonを読みに行く
+WebpackManifest.instance.load_content unless RunningEnv.using_webpack_dev_server?


### PR DESCRIPTION
Helper内でインスタンス変数を使うことを、結合度の観点から避けたかった。
https://www.rubydoc.info/gems/rubocop-rails/RuboCop/Cop/Rails/HelperInstanceVariable

また、Develop環境ではアクセスごとにmanifest.jsonにアクセスすべきだが、Productionでは最初に一度アクセスすれば十分である。
Singleton Classを用いて実現した。